### PR TITLE
FIX: log info on group upgrade retry message

### DIFF
--- a/src/services/notify.ts
+++ b/src/services/notify.ts
@@ -82,7 +82,7 @@ export const notify = async (
   }
   if (logTxt) {
     if (groupUpgraded) {
-      logger.trace(`Successfully sent message to ${subscribers}`);
+      logger.info(`Successfully sent message to ${subscribers}`);
     } else {
       logger.trace(`Text for all messages was:\n${text}`);
     }


### PR DESCRIPTION
The "retry" message after group upgrade should be clearly visible as success - thus log as info.